### PR TITLE
Reduce necessary user interaction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 FROM opensuse:tumbleweed
 MAINTAINER Ricardo Marques "rimarques@suse.com"
 
-RUN zypper -n install python lttng-ust-devel babeltrace-devel aaa_base
+RUN zypper ref && \
+    zypper -n dup && \
+    zypper -n install \
+        iproute2 net-tools-deprecated python2-pip python3-pip \
+        python lttng-ust-devel babeltrace-devel \
+        librados2 python-rados python2-pylint python3-pylint \
+        bash vim tmux git aaa_base ccache
 
-VOLUME  ["/ceph"]
+ADD setup-ceph.sh /root/bin/setup-ceph
+ADD bash.bashrc /etc/bash.bashrc
+
+VOLUME ["/ceph"]
+
+CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -37,17 +37,9 @@ Now start up the container, by mounting the local git clone directory as
 
     # docker run -it -v <ceph-repository>:/ceph --net=host ceph-dev-docker /bin/bash
 
-Please note that the mapped Ceph source cannot be used in the Docker container
-if `./do_cmake.sh` has been called previously with a path different from the one
-used by the Docker container. If it doesn't compile (due to wrong paths), use a
-dedicated Ceph source for the Docker container where `./do_cmake.sh` hasn't been
-called before, or remove the values cached by `cmake`.
+Inside the container, you can call `setup-ceph` to install dependencies and build Ceph.
 
-    # cd /ceph
-    # ./install-deps.sh
-    # ./do_cmake.sh -DWITH_PYTHON3=ON -DWITH_TESTS=OFF
-    # cd /ceph/build
-    # make -j$(nproc)
+    # setup-ceph -DWITH_PYTHON3=ON -DWITH_TESTS=OFF
 
 ### Create a new docker image with all dependencies installed (use a separate terminal)
 

--- a/bash.bashrc
+++ b/bash.bashrc
@@ -1,0 +1,7 @@
+alias ls='ls --color=auto'
+alias o='grep --color=auto'
+
+if [ ! -d ~/bin ]; then
+    mkdir ~/bin
+fi
+export PATH=~/bin:${PATH}

--- a/setup-ceph.sh
+++ b/setup-ceph.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cd /ceph
+./install-deps.sh
+./do_cmake.sh $@
+cd /ceph/build
+make -j$(nproc)
+
+pip install -r /ceph/src/pybind/mgr/dashboard_v2/requirements.txt


### PR DESCRIPTION
by an automatic installation of dependecies as well as providing a setup
routine for the clone and build process of Ceph.

This is the stripped-down version without the adaptation to switch to ZSH.

It also includes a few minor bug fixes like installing the `ss` and `ifconfig` tools which enable `vstart.sh` to determine the IP/host name correctly.