### PR TITLE
Add missing 'aaa_base' package that installs /etc/mime.types which is…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse:tumbleweed
 MAINTAINER Ricardo Marques "rimarques@suse.com"
 
-RUN zypper -n install python lttng-ust-devel babeltrace-devel
+RUN zypper -n install python lttng-ust-devel babeltrace-devel aaa_base
 
 VOLUME  ["/ceph"]


### PR DESCRIPTION
… required to run RGW.

Signed-off-by: Volker Theile <vtheile@suse.com>