### PR TITLE
Update dependencies in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM opensuse:tumbleweed
 MAINTAINER Ricardo Marques "rimarques@suse.com"
 
-RUN zypper ref && \
-    zypper -n dup && \
-    zypper -n install \
+RUN zypper ref
+RUN zypper -n dup
+RUN zypper -n install \
         iproute2 net-tools-deprecated python2-pip python3-pip \
         python lttng-ust-devel babeltrace-devel \
-        librados2 python-rados python2-pylint python3-pylint \
-        bash vim tmux git aaa_base ccache
+        librados2 python2-pylint python3-pylint \
+        bash vim tmux git aaa_base ccache \
+        python-devel python-Cython python-PrettyTable
 
 ADD setup-ceph.sh /root/bin/setup-ceph
 ADD bash.bashrc /etc/bash.bashrc

--- a/setup-ceph.sh
+++ b/setup-ceph.sh
@@ -8,4 +8,10 @@ cd /ceph
 cd /ceph/build
 make -j$(nproc)
 
-pip install -r /ceph/src/pybind/mgr/dashboard_v2/requirements.txt
+if which pip2; then
+    pip2 install -r /ceph/src/pybind/mgr/dashboard_v2/requirements.txt
+fi
+
+if which pip3; then
+    pip3 install -r /ceph/src/pybind/mgr/dashboard_v2/requirements.txt
+fi


### PR DESCRIPTION
* `python-devel` has been removed and trying to install it leads to an
  error.
* `python2-Cython` is required to compile Ceph and
* `python2-PrettyTable` is required for running Ceph commands.

Using more `RUN` statements enables the Docker cache for each statement. This will speed up the rebuild process of the Docker image in case of failures.