### PR TITLE
Dockerfile: Fixed adding the security zypper repo, removed installing oath-toolkit during the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM opensuse:tumbleweed
 LABEL maintainer="rimarques@suse.com"
 
-RUN zypper addrepo https://download.opensuse.org/repositories/security/openSUSE_Tumbleweed/security.repo
+RUN zypper ar https://download.opensuse.org/repositories/security/openSUSE_Tumbleweed/ security
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper -n dup
 RUN zypper -n install \
@@ -9,7 +9,7 @@ RUN zypper -n install \
         python lttng-ust-devel babeltrace-devel \
         librados2 python2-pylint python3-pylint \
         bash vim tmux git aaa_base ccache wget jq google-opensans-fonts \
-        oath-toolkit python-devel python-Cython python-PrettyTable psmisc \
+        python-devel python-Cython python-PrettyTable psmisc \
         python2-CherryPy python2-pecan python2-Jinja2 python2-pyOpenSSL
 
 RUN wget https://dl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
My apologies, the previous commit did not actually resolve the build error.

I fixed adding the `security` repo, and removed the installation of `liboath-devel`, as it's performed correctly by `./install-deps.sh` in the Ceph git repo.

This workaround can actually be removed once `oath-toolkit` has been [merged into Tumbleweed](https://build.opensuse.org/request/show/595675).

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>