### PR TITLE
Dockerfile: remove oath-toolkit installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM opensuse:tumbleweed
 LABEL maintainer="rimarques@suse.com"
 
-RUN zypper addrepo https://download.opensuse.org/repositories/security/openSUSE_Tumbleweed/security.repo
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper -n dup
 RUN zypper -n install \
@@ -9,7 +8,7 @@ RUN zypper -n install \
         python lttng-ust-devel babeltrace-devel \
         librados2 python2-pylint python3-pylint \
         bash vim tmux git aaa_base ccache wget jq google-opensans-fonts \
-        oath-toolkit python-devel python-Cython python-PrettyTable psmisc \
+        python-devel python-Cython python-PrettyTable psmisc \
         python2-CherryPy python2-pecan python2-Jinja2 python2-pyOpenSSL
 
 RUN wget https://dl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
Remove the additional `security` zypper repository and explicit installation of `oath-toolkit` again. The package has now been added to Tumbleweed (see https://build.opensuse.org/request/show/595675),
and the package gets installed by `install-deps.sh` included in the Ceph git repo.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>