### PR TITLE
shibboleth IDP and SP docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ After starting all containers, the following external services will be available
 | Keycloak       | http://localhost:8080 | admin                      | admin |
 | LDAP           | ldap://localhost:2389 | cn=admin,dc=example,dc=org | admin |
 | PHP LDAP Admin | https://localhost:90  | cn=admin,dc=example,dc=org | admin |
+| Shibboleth     | http://localhost:9080/Shibboleth.sso/Status |      |       |
 
 > Please note that Grafana isn't configured automatically for you, so you
 will have to follow these

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ After starting all containers, the following external services will be available
 | Keycloak       | http://localhost:8080 | admin                      | admin |
 | LDAP           | ldap://localhost:2389 | cn=admin,dc=example,dc=org | admin |
 | PHP LDAP Admin | https://localhost:90  | cn=admin,dc=example,dc=org | admin |
-| Shibboleth     | http://localhost:9080/Shibboleth.sso/Status |      |       |
+| Shibboleth     | http://localhost:9080/Shibboleth.sso/Login | admin     | admin |
 
 > Please note that Grafana isn't configured automatically for you, so you
 will have to follow these

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,13 @@ services:
       - "90:443"
     links:
       - openldap
+
+  shibboleth:
+    build:
+      context: ./shibboleth
+      dockerfile: Dockerfile
+    ports:
+      - "9080:9080"
+      - "9443:9443"
+    links:
+      - openldap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
 
   openldap:
     image: osixia/openldap:1.2.0
+    environment:
+      LDAP_TLS_VERIFY_CLIENT: try
     ports:
       - "2389:389"
 

--- a/shibboleth/Dockerfile
+++ b/shibboleth/Dockerfile
@@ -46,7 +46,10 @@ RUN sed -i -e 's!localhost/!localhost:9443/!g' /opt/shibboleth-idp/metadata/idp-
 RUN sed -i -e 's/#idp.encryption.optional = false/idp.encryption.optional = true/g' /opt/shibboleth-idp/conf/idp.properties
 ADD files/metadata-providers.xml /opt/shibboleth-idp/conf/
 
+ADD files/ldap.properties /opt/shibboleth-idp/conf/
 ADD files/start.sh /
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /
+RUN chmod +x /wait-for-it.sh
 
 ENTRYPOINT [ "/start.sh" ]
 

--- a/shibboleth/Dockerfile
+++ b/shibboleth/Dockerfile
@@ -1,0 +1,52 @@
+FROM opensuse:tumbleweed
+
+RUN zypper --gpg-auto-import-keys ref
+RUN zypper -n dup
+RUN zypper -n install java-1_8_0-openjdk-devel curl wget tar
+ENV JAVA_HOME=/usr/lib64/jvm/java-1.8.0-openjdk
+RUN curl https://shibboleth.net/downloads/identity-provider/latest/shibboleth-identity-provider-3.3.3.tar.gz \
+         --output shibboleth-identity-provider-3.3.3.tar.gz
+RUN curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.10.v20180503/jetty-distribution-9.4.10.v20180503.tar.gz \
+        --output jetty-distribution-9.4.10.v20180503.tar.gz
+
+RUN tar zxvf shibboleth-identity-provider-3.3.3.tar.gz
+RUN sed -i -e 's!idp.entityID = https://idp.example.org!idp.entityID = https://ceph-dashboard/idp!g' /shibboleth-identity-provider-3.3.3/conf/idp.properties
+RUN sed -i -e 's!idp.scope = example.org!idp.scope = ceph-dev-docker.org!g' /shibboleth-identity-provider-3.3.3/conf/idp.properties
+RUN cd shibboleth-identity-provider-3.3.3 && \
+    ./bin/install.sh -Didp.target.dir=/opt/shibboleth-idp -Didp.host.name=localhost \
+                     -Didp.src.dir=/shibboleth-identity-provider-3.3.3 -Didp.noprompt=true \
+                     -Didp.merge.properties=conf/idp.properties -Didp.scope=ceph-dev-docker.org \
+                     -Didp.keystore.password=password -Didp.sealer.password=password
+
+RUN tar zxvf jetty-distribution-9.4.10.v20180503.tar.gz
+ENV JETTY_HOME=/jetty-distribution-9.4.10.v20180503
+RUN keytool -noprompt -genkey -keystore "$JETTY_HOME/etc/rc.keystore" \
+    -alias cephkeystore -keyalg RSA -keypass helloworld -storepass helloworld \
+    -dname "CN=shibboleth.ceph.com, OU=ID, O=ceph, L=Hello, S=Hello, C=GB" \
+    -storetype pkcs12
+ADD files/jetty-ssl-context.xml $JETTY_HOME/etc/
+RUN sed -i -e 's/8080/9080/g' $JETTY_HOME/etc/jetty-http.xml
+RUN sed -i -e 's/8443/9443/g' $JETTY_HOME/etc/jetty.xml
+RUN sed -i -e 's/8443/9443/g' $JETTY_HOME/etc/jetty-ssl.xml
+RUN sed -i -e 's/--module=http/--module=https/g' $JETTY_HOME/start.ini
+
+RUN zypper -n install which psmisc
+
+RUN cp /opt/shibboleth-idp/war/idp.war $JETTY_HOME/webapps/
+
+RUN zypper -n install apache2 shibboleth-sp
+RUN sed -i -e 's/Listen 80/Listen 9080/g' /etc/apache2/listen.conf
+ADD files/shibboleth2.xml /etc/shibboleth/
+RUN shibd && httpd && cd /opt/shibboleth-idp && \
+    curl http://localhost:9080/Shibboleth.sso/Metadata --output metadata/sp-metadata.xml && \
+    killall httpd && killall shibd
+
+RUN sed -i -e 's!localhost:8443!localhost:9443!g' /opt/shibboleth-idp/metadata/idp-metadata.xml
+RUN sed -i -e 's!localhost/!localhost:9443/!g' /opt/shibboleth-idp/metadata/idp-metadata.xml
+RUN sed -i -e 's/#idp.encryption.optional = false/idp.encryption.optional = true/g' /opt/shibboleth-idp/conf/idp.properties
+ADD files/metadata-providers.xml /opt/shibboleth-idp/conf/
+
+ADD files/start.sh /
+
+ENTRYPOINT [ "/start.sh" ]
+

--- a/shibboleth/files/jetty-ssl-context.xml
+++ b/shibboleth/files/jetty-ssl-context.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+  <Set name="Provider"><Property name="jetty.sslContext.provider"/></Set>
+  <Set name="KeyStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.sslContext.keyStorePath" deprecated="jetty.keystore" default="etc/rc.keystore"/></Set>
+  <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" deprecated="jetty.keystore.password" default="helloworld"/></Set>
+  <Set name="KeyStoreType"><Property name="jetty.sslContext.keyStoreType" default="PKCS12"/></Set>
+  <Set name="KeyStoreProvider"><Property name="jetty.sslContext.keyStoreProvider"/></Set>
+  <Set name="KeyManagerPassword"><Property name="jetty.sslContext.keyManagerPassword" deprecated="jetty.keymanager.password" default="helloworld"/></Set>
+  <Set name="TrustStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.sslContext.trustStorePath" deprecated="jetty.truststore" default="etc/rc.keystore"/></Set>
+  <Set name="TrustStorePassword"><Property name="jetty.sslContext.trustStorePassword" deprecated="jetty.truststore.password"/></Set>
+  <Set name="TrustStoreType"><Property name="jetty.sslContext.trustStoreType"/></Set>
+  <Set name="TrustStoreProvider"><Property name="jetty.sslContext.trustStoreProvider"/></Set>
+  <Set name="EndpointIdentificationAlgorithm"></Set>
+  <Set name="NeedClientAuth"><Property name="jetty.sslContext.needClientAuth" deprecated="jetty.ssl.needClientAuth" default="false"/></Set>
+  <Set name="WantClientAuth"><Property name="jetty.sslContext.wantClientAuth" deprecated="jetty.ssl.wantClientAuth" default="false"/></Set>
+  <Set name="useCipherSuitesOrder"><Property name="jetty.sslContext.useCipherSuitesOrder" default="true"/></Set>
+  <Set name="sslSessionCacheSize"><Property name="jetty.sslContext.sslSessionCacheSize" default="-1"/></Set>
+  <Set name="sslSessionTimeout"><Property name="jetty.sslContext.sslSessionTimeout" default="-1"/></Set>
+  <Set name="RenegotiationAllowed"><Property name="jetty.sslContext.renegotiationAllowed" default="true"/></Set>
+  <Set name="RenegotiationLimit"><Property name="jetty.sslContext.renegotiationLimit" default="5"/></Set>
+
+</Configure>

--- a/shibboleth/files/ldap.properties
+++ b/shibboleth/files/ldap.properties
@@ -1,0 +1,19 @@
+idp.authn.LDAP.authenticator                   = directAuthenticator
+idp.authn.LDAP.ldapURL                          = ldaps://#LDAPHOST#:636
+idp.authn.LDAP.useStartTLS                     = false
+idp.authn.LDAP.useSSL                          = true
+idp.authn.LDAP.trustCertificates                = %{idp.home}/credentials/ldap-server.crt
+idp.authn.LDAP.trustStore                       = %{idp.home}/credentials/ldap-server.truststore
+idp.authn.LDAP.returnAttributes                 = *
+idp.authn.LDAP.dnFormat                         = cn=%s,dc=example,dc=org
+
+
+idp.attribute.resolver.LDAP.ldapURL             = %{idp.authn.LDAP.ldapURL}
+idp.attribute.resolver.LDAP.connectTimeout      = %{idp.authn.LDAP.connectTimeout:PT3S}
+idp.attribute.resolver.LDAP.responseTimeout     = %{idp.authn.LDAP.responseTimeout:PT3S}
+idp.attribute.resolver.LDAP.baseDN              = %{idp.authn.LDAP.baseDN:undefined}
+idp.attribute.resolver.LDAP.bindDN              = %{idp.authn.LDAP.bindDN:undefined}
+idp.attribute.resolver.LDAP.bindDNCredential    = %{idp.authn.LDAP.bindDNCredential:undefined}
+idp.attribute.resolver.LDAP.useStartTLS         = %{idp.authn.LDAP.useStartTLS:true}
+idp.attribute.resolver.LDAP.trustCertificates   = %{idp.authn.LDAP.trustCertificates:undefined}
+idp.attribute.resolver.LDAP.searchFilter        = (uid=$resolutionContext.principal)

--- a/shibboleth/files/metadata-providers.xml
+++ b/shibboleth/files/metadata-providers.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MetadataProvider id="ShibbolethMetadata" xsi:type="ChainingMetadataProvider"
+    xmlns="urn:mace:shibboleth:2.0:metadata"
+    xmlns:resource="urn:mace:shibboleth:2.0:resource"
+    xmlns:security="urn:mace:shibboleth:2.0:security"
+    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:mace:shibboleth:2.0:metadata http://shibboleth.net/schema/idp/shibboleth-metadata.xsd
+                        urn:mace:shibboleth:2.0:resource http://shibboleth.net/schema/idp/shibboleth-resource.xsd
+                        urn:mace:shibboleth:2.0:security http://shibboleth.net/schema/idp/shibboleth-security.xsd
+                        urn:oasis:names:tc:SAML:2.0:metadata http://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd">
+
+    <MetadataProvider id="LocalMetadata"
+                      xsi:type="FilesystemMetadataProvider"
+                      metadataFile="/opt/shibboleth-idp/metadata/sp-metadata.xml"/>
+
+</MetadataProvider>

--- a/shibboleth/files/shibboleth2.xml
+++ b/shibboleth/files/shibboleth2.xml
@@ -1,0 +1,53 @@
+<SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config"
+    xmlns:conf="urn:mace:shibboleth:2.0:native:sp:config"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    clockSkew="180">
+
+
+    <ApplicationDefaults entityID="http://ceph-dashboard/sp"
+                         REMOTE_USER="eppn persistent-id targeted-id">
+
+        <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
+                  checkAddress="false" handlerSSL="false" cookieProps="http">
+
+            <SSO entityID="https://ceph-dashboard/idp"
+                 discoveryProtocol="SAMLDS" discoveryURL="https://ds.example.org/DS/WAYF">
+              SAML2 SAML1
+            </SSO>
+
+            <Logout>SAML2 Local</Logout>
+
+            <Handler type="MetadataGenerator" Location="/Metadata" signing="false"/>
+
+            <Handler type="Status" Location="/Status" acl="0.0.0.0/0"/>
+
+            <Handler type="Session" Location="/Session" showAttributeValues="false"/>
+
+            <Handler type="DiscoveryFeed" Location="/DiscoFeed"/>
+        </Sessions>
+
+        <Errors supportContact="root@localhost"
+            helpLocation="/about.html"
+            styleSheet="/shibboleth-sp/main.css"/>
+
+
+        <MetadataProvider type="XML" validate="true" file="/opt/shibboleth-idp/metadata/idp-metadata.xml"/>
+
+        <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
+
+        <AttributeResolver type="Query" subjectMatch="true"/>
+
+        <AttributeFilter type="XML" validate="true" path="attribute-policy.xml"/>
+
+        <CredentialResolver type="File" key="sp-key.pem" certificate="sp-cert.pem"/>
+
+
+    </ApplicationDefaults>
+
+    <SecurityPolicyProvider type="XML" validate="true" path="security-policy.xml"/>
+
+    <ProtocolProvider type="XML" validate="true" reloadChanges="false" path="protocols.xml"/>
+
+</SPConfig>

--- a/shibboleth/files/start.sh
+++ b/shibboleth/files/start.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# LDAP configuration
+echo "Waiting for LDAP server"
+/wait-for-it.sh openldap:636 --strict
+
+echo "LDAP server is ready"
+
+echo -n | openssl s_client -connect openldap:636 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /opt/shibboleth-idp/credentials/ldap-server.crt
+LDAPHOST=`echo -n | openssl s_client -connect openldap:636 | grep CN= | head -1 | sed -e 's/.*CN=\(.*\)/\1/'`
+sed -i -e "s/#LDAPHOST#/$LDAPHOST/g" /opt/shibboleth-idp/conf/ldap.properties
+
 httpd
 shibd -f
 $JETTY_HOME/bin/jetty.sh start

--- a/shibboleth/files/start.sh
+++ b/shibboleth/files/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+httpd
+shibd -f
+$JETTY_HOME/bin/jetty.sh start
+tail -f /opt/shibboleth-idp/logs/idp-process.log


### PR DESCRIPTION
This PR adds a new container that deploys a shibboleth Identity Provider (IDP) and an apache2 configured with the shibboleth Service Provider (SP) to allow the testing of the IDP.

The IDP is configured to use the LDAP server that is deployed by the openldap container.

After the shibboleth container is started you can access `http://localhost:9080/Shibboleth.sso/Login` to preform the login. If the user is not authenticated yet, it will be redirected to the IDP SSO page.
In the SSO page, you can use the "admin" user credentials configured in LDAP to authenticate.

