### PR TITLE
Build test dependecies when building Ceph

### DIFF
--- a/bin/setup-ceph.sh
+++ b/bin/setup-ceph.sh
@@ -6,7 +6,7 @@ cd /ceph
 find . -name \*.pyc -delete
 ./install-deps.sh
 
-ARGS="-DWITH_PYTHON3=ON -DWITH_TESTS=OFF -DWITH_CCACHE=ON $ARGS"
+ARGS="-DWITH_PYTHON3=ON -DWITH_TESTS=ON -DWITH_CCACHE=ON $ARGS"
 NPROC=${NPROC:-$(nproc --ignore=2)}
 
 if [ -d "build" ]; then


### PR DESCRIPTION
with `bin/setup-ceph.sh`. This change has gotten neccessary due to a
change in `vstart_runner.sh` which now requires the `ceph-dencoder`
binary to be present when it checks for required dependecies. Otherwise
it'll complain and abort when running `run-backend-api-tests.sh`.