### PR TITLE
Add static port to be used by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM opensuse:tumbleweed
 LABEL maintainer="rimarques@suse.com"
 
+ENV CEPH_PORT=8080
+
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper -n dup
 RUN zypper -n install \


### PR DESCRIPTION
Prevents that `vstart.sh` uses a random port on each run.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>