### PR TITLE
docker-compose.yml: Added missing Grafana plugins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
 
   grafana:
     image: 'grafana/grafana'
+    environment:
+      GF_INSTALL_PLUGINS: vonage-status-panel,grafana-piechart-panel
     container_name: 'grafana'
     network_mode: 'host'
     volumes:


### PR DESCRIPTION
Adding `vonage-status-panel` and `grafana-piechart-panel` as outlined in the [installation documentation](http://docs.ceph.com/docs/master/mgr/dashboard/#enabling-the-embedding-of-grafana-dashboards).

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>