### PR TITLE
mgr/dashboard/docker: Add the Prometheus Alertmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,44 @@ After starting all containers, the following external services will be available
 | -------------- | --------------------- | -------------------------- | ----- |
 | Grafana        | http://localhost:3000 | admin                      | admin |
 | Prometheus     | http://localhost:9090 | -                          | -     |
+| Alertmanager   | http://localhost:9093 | -                          | -     |
 | Node Exporter  | http://localhost:9100 | -                          | -     |
 | Keycloak       | http://localhost:8080 | admin                      | admin |
 | LDAP           | ldap://localhost:2389 | cn=admin,dc=example,dc=org | admin |
 | PHP LDAP Admin | https://localhost:90  | cn=admin,dc=example,dc=org | admin |
 | Shibboleth     | http://localhost:9080/Shibboleth.sso/Login | admin     | admin |
+
+### Using Prometheus
+
+All ports in use can be found in `prometheus/prometheus.yml`.
+
+To start Prometheus, Grafana and Node exporter, run:
+
+    docker-compose up alertmanager grafana node-exporter prometheus
+
+In order to connect with prometheus to your running docker instance, enable prometheus in it with:
+
+    ceph mgr module enable prometheus
+
+Now the following services should be found:
+
+* [Ceph metrics](http://localhost:9100/metrics)
+* [Prometheus](http://localhost:9090)
+* [Alertmanager](http://localhost:9093)
+* [Grafana](http://localhost:3000)
+
+In order to enable connections from the dashboard to the Alertmanager API run:
+
+    ceph dashboard set-alertmanager-api-host 'http://localhost:9093'
+
+After you have connected the API to the dashboard reload the page.
+After some minutes you should see a new tab inside the notification popover.
+The monitoring tab should have at least one active alert named 'load0'.
+
+There are 7 alerts configured, you can find them in 'prometheus/alert.rules'.
+The alerts have nothing to do with your cluster state (ATM), just with your system load.
+'load0' fires if your system load is greater than zero, this means it's always on.
+
 
 ### Configure SSO
 

--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -1,0 +1,10 @@
+route:
+  receiver: 'ceph-dashboard'
+  group_wait: 1m
+  group_interval: 1m
+  repeat_interval: 1m
+
+receivers:
+  - name: 'ceph-dashboard'
+    webhook_configs:
+    - url: 'http://localhost:4200/api/prometheus_receiver'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,18 @@ services:
   prometheus:
     image: 'quay.io/prometheus/prometheus'
     volumes:
-      - './prometheus.yml:/etc/prometheus/prometheus.yml:ro'
+      - './prometheus:/etc/prometheus'
     container_name: 'prometheus'
+    network_mode: 'host'
+
+  alertmanager:
+    image: 'quay.io/prometheus/alertmanager'
+    volumes:
+      - './alertmanager/:/etc/alertmanager/'
+    container_name: 'alertmanager'
+    command:
+      - '--config.file=/etc/alertmanager/config.yml'
+      - '--storage.path=/alertmanager'
     network_mode: 'host'
 
   grafana:

--- a/prometheus/alert.rules
+++ b/prometheus/alert.rules
@@ -1,0 +1,66 @@
+groups:
+- name: test
+  rules:
+
+  - alert: load_0
+    expr: node_load1 > 0
+    for: 10s
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} load is over 0!"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} load is over 0!"
+
+  - alert: load_1
+    expr: node_load1 > 1 and node_load1 > 3
+    for: 30s
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} with load between 1 and 3"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 1 and 3."
+
+  - alert: load_2
+    expr: node_load1 > 2 and node_load1 > 4
+    for: 25s
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} with load between 2 and 4"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 2 and 4."
+
+  - alert: load_3
+    expr: node_load1 > 3 and node_load1 > 5
+    for: 20s
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} with load between 3 and 5"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 3 and 5."
+
+  - alert: load_4
+    expr: node_load1 > 4 and node_load1 > 6
+    for: 15s
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} with load between 4 and 6"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 4 and 6."
+
+  - alert: load_5
+    expr: node_load1 > 5 and node_load1 > 7
+    for: 10s
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} with load between 5 and 7"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 5 and 7."
+
+  - alert: load_6
+    expr: node_load1 > 6
+    for: 5s
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} with load over 6 for 10s."
+      description: "{{ $labels.instance }} of job {{ $labels.job }} with load over 6 for 10s."

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,3 +11,13 @@ scrape_configs:
   - job_name: 'node-exporter'
     static_configs:
       - targets: ['localhost:9100']
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - 'localhost:9093'
+
+rule_files:
+ - 'alert.rules'


### PR DESCRIPTION
Included some example rules, with one that is always failing, in order
to test alerts easily. Extended the documentation on how to use it.

Fixes: https://tracker.ceph.com/issues/37585
Signed-off-by: Stephan Müller <smueller@suse.com>