### PR TITLE
Dockerfile: removed installation of librados2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN zypper -n dup
 RUN zypper -n install \
         iproute2 net-tools-deprecated python2-pip python3-pip \
         python lttng-ust-devel babeltrace-devel \
-        librados2 python2-pylint python3-pylint \
+        python2-pylint python3-pylint \
         bash vim tmux git aaa_base ccache wget jq google-opensans-fonts \
         python-devel python3-devel python-Cython python3-Cython \
         python-PrettyTable python3-PrettyTable psmisc python2-CherryPy \


### PR DESCRIPTION
Building the ceph-dev-docker container failed with an installation
error: "No provider of 'librados2' found.". Fixed by removing the
package from the list of packages to be installed.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>