### PR TITLE
docker-compose.yml: fixed permission issues when starting prometheus 2.6 container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   node-exporter:
     user: 'root'
-    image: 'quay.io/prometheus/node-exporter'
+    image: 'prom/node-exporter'
     volumes:
       - '/proc:/host/proc:ro'
       - '/sys:/host/sys:ro'
@@ -13,14 +13,15 @@ services:
               '--path.sysfs', '/host/sys',
               '--collector.filesystem.ignored-mount-points', '^/(sys|proc|dev|host|etc)($$|/)']
   prometheus:
-    image: 'quay.io/prometheus/prometheus'
+    image: 'prom/prometheus'
     volumes:
-      - './prometheus:/etc/prometheus'
+      - './prometheus/alert.rules:/etc/prometheus/alert.rules'
+      - './prometheus/prometheus.yml:/etc/prometheus/prometheus.yml'
     container_name: 'prometheus'
     network_mode: 'host'
 
   alertmanager:
-    image: 'quay.io/prometheus/alertmanager'
+    image: 'prom/alertmanager'
     volumes:
       - './alertmanager/:/etc/alertmanager/'
     container_name: 'alertmanager'


### PR DESCRIPTION
Also updated image names to match the naming convention in the [upstream installation instructions](https://prometheus.io/docs/prometheus/latest/installation/#using-docker)

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>