### PR TITLE
Add `ceph-dev-vagrant` iSCSI gateways automatically

### DIFF
--- a/shared/bin/start-ceph.sh
+++ b/shared/bin/start-ceph.sh
@@ -18,3 +18,8 @@ setup-proxy.sh
 ./bin/ceph dashboard set-rgw-api-user-id dev
 ./bin/ceph dashboard set-rgw-api-access-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].access_key | sed -e 's/^"//' -e 's/"$//'`
 ./bin/ceph dashboard set-rgw-api-secret-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].secret_key | sed -e 's/^"//' -e 's/"$//'`
+./bin/ceph dashboard iscsi-gateway-add node1 http://admin:admin@192.168.100.201:5001
+./bin/ceph dashboard iscsi-gateway-add node2 http://admin:admin@192.168.100.202:5001
+./bin/ceph dashboard iscsi-gateway-add node3 http://admin:admin@192.168.100.203:5001
+./bin/ceph dashboard iscsi-gateway-list
+


### PR DESCRIPTION
Signed-off-by: Ricardo Marques <rimarques@suse.com>