### PR TITLE
start-ceph.sh: split out RGW configuration

### DIFF
--- a/shared/bin/create-dashboard-rgw-user.sh
+++ b/shared/bin/create-dashboard-rgw-user.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+#--------------
+# Configure RGW
+#--------------
+
+./bin/radosgw-admin user create --uid=dev --display-name=Developer --system
+./bin/ceph dashboard set-rgw-api-user-id dev
+./bin/ceph dashboard set-rgw-api-access-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].access_key | sed -e 's/^"//' -e 's/"$//'`
+./bin/ceph dashboard set-rgw-api-secret-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].secret_key | sed -e 's/^"//' -e 's/"$//'`

--- a/shared/bin/start-ceph.sh
+++ b/shared/bin/start-ceph.sh
@@ -8,13 +8,4 @@ cd /ceph/build
 RGW=1 ../src/vstart.sh -d -n -x
 
 setup-proxy.sh
-
-#--------------
-# Configure RGW
-#--------------
-
-./bin/radosgw-admin user create --uid=dev --display-name=Developer --system
-
-./bin/ceph dashboard set-rgw-api-user-id dev
-./bin/ceph dashboard set-rgw-api-access-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].access_key | sed -e 's/^"//' -e 's/"$//'`
-./bin/ceph dashboard set-rgw-api-secret-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].secret_key | sed -e 's/^"//' -e 's/"$//'`
+create-dashboard-rgw-user.sh


### PR DESCRIPTION
Move dashboard RGW configuration into a
separate file `create-dashboard-rgw-user.sh`
in order to be able to run this step separately.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>