### PR TITLE
Simplify RGW user creation

### DIFF
--- a/shared/bin/create-dashboard-rgw-user.sh
+++ b/shared/bin/create-dashboard-rgw-user.sh
@@ -8,5 +8,5 @@ set -e
 
 ./bin/radosgw-admin user create --uid=dev --display-name=Developer --system
 ./bin/ceph dashboard set-rgw-api-user-id dev
-./bin/ceph dashboard set-rgw-api-access-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].access_key | sed -e 's/^"//' -e 's/"$//'`
-./bin/ceph dashboard set-rgw-api-secret-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].secret_key | sed -e 's/^"//' -e 's/"$//'`
+./bin/ceph dashboard set-rgw-api-access-key `./bin/radosgw-admin user info --uid=dev | jq -r ".keys[0].access_key"`
+./bin/ceph dashboard set-rgw-api-secret-key `./bin/radosgw-admin user info --uid=dev | jq -r ".keys[0].secret_key"`


### PR DESCRIPTION

Improved `create-dashboard-rgw-user.sh` by removing a superflouous `sed` call.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>