### PR TITLE
Set SOURCE_DATE_EPOCH to 946684800 in .zshrc

### DIFF
--- a/shared/bin/setup-ceph.sh
+++ b/shared/bin/setup-ceph.sh
@@ -8,7 +8,6 @@ cd /ceph
 find . -name \*.pyc -delete
 ./install-deps.sh
 
-export SOURCE_DATE_EPOCH=0
 ARGS="-DENABLE_GIT_VERSION=OFF -DWITH_TESTS=ON -DWITH_CCACHE=ON $ARGS"
 if [ "$WITH_PYTHON" == 3 ]; then
     ARGS="-DWITH_PYTHON3=ON -DWITH_PYTHON2=OFF -DMGR_PYTHON_VERSION=3 $ARGS"

--- a/shared/zsh/.zshrc
+++ b/shared/zsh/.zshrc
@@ -70,7 +70,7 @@ source $ZSH/oh-my-zsh.sh
 # User configuration
 
 # export MANPATH="/usr/local/man:$MANPATH"
-export SOURCE_DATE_EPOCH=0
+export SOURCE_DATE_EPOCH=946684800
 
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8


### PR DESCRIPTION
Setting `SOURCE_DATE_EPOCH` to `0` had some weird side effects when building Python modules. Setting the date to `946684800` (2001-01-01) in `.zshrc` and removing the duplicate definition `setup-ceph.sh` should fix this.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>