### PR TITLE
Add mimic dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ environment.
 `docker` command requires root privileges.
 To remove this requirement you can join the `docker` user group.
 
+### Older ceph releases
+
+When developing for older ceph versions you should use the dedicated dockerfile
+for that release, p.e. we have a `mimic.Dockerfile`.
+
+To create a container with that dockerfile you can either call `setup.sh` with
+`VERSION` var specified or add `-f <version>.Dockerfile` to the docker build
+command.
+
 ### setup.sh
 
 This script can be used to get a working container with 1 command.
@@ -31,6 +40,8 @@ You can customize the outcome of the script with the following env variables:
 change this. default: `ceph-1`.
 - `CEPH` - Path to the ceph repository. default: `../ceph`
 - `CCACHE` - Path to ccache. default: `../ceph-ccache`
+- `VERSION` - Specify an already released ceph version which you are going work
+on. Available versions: `mimic`.
 
 Note: CEPH and CCACHE need to be absolute paths.
 

--- a/mimic.Dockerfile
+++ b/mimic.Dockerfile
@@ -1,20 +1,19 @@
-FROM opensuse/tumbleweed
+FROM opensuse/leap:15.0
 LABEL maintainer="rimarques@suse.com"
 
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper -n dup
 RUN zypper -n install \
-        iproute2 net-tools-deprecated zsh lttng-ust-devel babeltrace-devel \
-        bash vim tmux git aaa_base ccache wget jq google-opensans-fonts psmisc \
+        aaa_base babeltrace-devel bash bzip2 ccache git \
+        google-opensans-fonts iproute2 jq lttng-ust-devel \
+        net-tools-deprecated psmisc tmux vim wget zsh \
         python python2-pip python3-pip \
         python-devel python3-devel \
         python2-bcrypt python3-bcrypt \
         python2-CherryPy python3-CherryPy \
         python2-Cython python3-Cython \
-        python2-Jinja2 python3-Jinja2 \
         python2-pecan python3-pecan \
         python2-PrettyTable python3-PrettyTable \
-        python2-PyJWT python3-PyJWT \
         python2-pylint python3-pylint \
         python2-pyOpenSSL python3-pyOpenSSL \
         python2-requests python3-requests \
@@ -33,6 +32,7 @@ RUN /docker/install-omz.sh
 
 ENV CEPH_ROOT /ceph
 ENV BUILD_DIR /ceph/build
+ENV MIMIC true
 
 VOLUME ["/ceph"]
 VOLUME ["/shared"]

--- a/setup.sh
+++ b/setup.sh
@@ -3,13 +3,23 @@ WORKSPACE="$(dirname "$(pwd)")"
 NAME="${NAME:-ceph-1}"
 CEPH="${CEPH:-$WORKSPACE/ceph}"
 CCACHE="${CCACHE:-$WORKSPACE/ceph-ccache}"
+VERSION="${VERSION:-master}"
 
 # Removes old container with same name
 docker stop $NAME
 docker rm $NAME
 
 # Build updated version of the image
-docker build -t ceph-dev-docker .
+case "$VERSION" in
+"mimic")
+  TAG="ceph-dev-docker-mimic"
+  docker build -t $TAG -f mimic.Dockerfile .
+  ;;
+*)
+  TAG="ceph-dev-docker"
+  docker build -t $TAG .
+  ;;
+esac
 
 # Creates a container with all recommended configs
 docker run -itd \
@@ -20,4 +30,6 @@ docker run -itd \
   --name=$NAME \
   --hostname=$NAME \
   --add-host=$NAME:127.0.0.1 \
-  ceph-dev-docker
+  $TAG
+
+docker exec -it $NAME zsh

--- a/shared/bin/setup-ceph.sh
+++ b/shared/bin/setup-ceph.sh
@@ -19,15 +19,15 @@ fi
 
 NPROC=${NPROC:-$(nproc --ignore=2)}
 
-if [ "$MIMIC" == "true" ]; then
-    rm /usr/bin/gcc
-    rm /usr/bin/g++
-
-    ln -s /usr/bin/gcc-7 /usr/bin/gcc
-    ln -s /usr/bin/g++-7 /usr/bin/g++
+if [ "$MIMIC" != "true" ]; then
+    # SSO dependencies
+    zypper -n install libxmlsec1-1 libxmlsec1-nss1 libxmlsec1-openssl1 xmlsec1-devel xmlsec1-openssl-devel
+    pip install python3-saml
+    pip2 install python-saml
 fi
 
 if [ "$CLEAN" == "true" ]; then
+    echo "CLEAN INSTALL"
     rm -rf /ceph/build/
     rm -rf /ceph/src/pybind/mgr/dashboard/frontend/node_modules/
     rm -rf /ceph/src/pybind/mgr/dashboard/frontend/dist/
@@ -44,7 +44,3 @@ fi
 
 ccache make -j$NPROC
 
-# SSO dependencies
-zypper -n install libxmlsec1-1 libxmlsec1-nss1 libxmlsec1-openssl1 xmlsec1-devel xmlsec1-openssl-devel
-pip install python3-saml
-pip2 install python-saml

--- a/shared/docker/install-chrome.sh
+++ b/shared/docker/install-chrome.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+wget https://dl.google.com/linux/linux_signing_key.pub
+rpm --import linux_signing_key.pub
+zypper ar http://dl.google.com/linux/chrome/rpm/stable/x86_64 google
+zypper -n in google-chrome-stable

--- a/shared/docker/install-omz.sh
+++ b/shared/docker/install-omz.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+sh -c "$(wget https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
+# sym link for .zshrc
+rm /root/.zshrc
+ln -s /shared/zsh/.zshrc /root/.zshrc
+# sym link for dash.plugin.zsh
+mkdir ~/.oh-my-zsh/custom/plugins/dash
+ln -s /shared/zsh/dash.plugin.zsh ~/.oh-my-zsh/custom/plugins/dash/dash.plugin.zsh

--- a/shared/zsh/.zshrc
+++ b/shared/zsh/.zshrc
@@ -71,6 +71,7 @@ source $ZSH/oh-my-zsh.sh
 
 # export MANPATH="/usr/local/man:$MANPATH"
 export SOURCE_DATE_EPOCH=946684800
+export PATH=/shared/bin:${PATH}
 
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8
@@ -96,3 +97,6 @@ export SOURCE_DATE_EPOCH=946684800
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+alias cdb='cd /ceph/build'
+alias cdbd='cd /ceph/build/src/pybind/mgr/dashboard'
+alias cdsd='cd /ceph/src/pybind/mgr/dashboard'

--- a/shared/zsh/dash.plugin.zsh
+++ b/shared/zsh/dash.plugin.zsh
@@ -25,7 +25,3 @@ _dash() {
 
 compdef _dash dash
 
-alias cdb='cd /ceph/build'
-alias cdbd='cd /ceph/build/src/pybind/mgr/dashboard'
-alias cdsd='cd /ceph/src/pybind/mgr/dashboard'
-export PATH=/shared/bin:${PATH}


### PR DESCRIPTION
* Removed gcc7 scripts, leap:15 still uses that version and
nautilus doesn't require it.
* Extracted chrome and zsh installation to separate scripts.
* Setup.sh now creates different docker images for each release.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`