### PR TITLE
Modify configuration for prometheus-webhook-snmp

### DIFF
--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -8,3 +8,4 @@ receivers:
   - name: 'ceph-dashboard'
     webhook_configs:
     - url: 'http://localhost:4200/api/prometheus_receiver'
+    - url: 'http://localhost:9099/'

--- a/prometheus/alert.rules
+++ b/prometheus/alert.rules
@@ -6,7 +6,8 @@ groups:
     expr: node_load1 > 0
     for: 10s
     labels:
-      severity: page
+      severity: info
+      foo: bar
     annotations:
       summary: "Instance {{ $labels.instance }} load is over 0!"
       description: "{{ $labels.instance }} of job {{ $labels.job }} load is over 0!"
@@ -15,7 +16,8 @@ groups:
     expr: node_load1 > 1 and node_load1 > 3
     for: 30s
     labels:
-      severity: page
+      severity: info
+      oid: 1.3.6.1.4.1.50495.15.1.2.50.1
     annotations:
       summary: "Instance {{ $labels.instance }} with load between 1 and 3"
       description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 1 and 3."
@@ -24,7 +26,8 @@ groups:
     expr: node_load1 > 2 and node_load1 > 4
     for: 25s
     labels:
-      severity: page
+      severity: warning
+      oid: 1.3.6.1.4.1.50495.15.1.2.50.2
     annotations:
       summary: "Instance {{ $labels.instance }} with load between 2 and 4"
       description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 2 and 4."
@@ -33,7 +36,8 @@ groups:
     expr: node_load1 > 3 and node_load1 > 5
     for: 20s
     labels:
-      severity: page
+      severity: warning
+      oid: 1.3.6.1.4.1.50495.15.1.2.50.3
     annotations:
       summary: "Instance {{ $labels.instance }} with load between 3 and 5"
       description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 3 and 5."
@@ -42,7 +46,8 @@ groups:
     expr: node_load1 > 4 and node_load1 > 6
     for: 15s
     labels:
-      severity: page
+      severity: warning
+      oid: 1.3.6.1.4.1.50495.15.1.2.50.4
     annotations:
       summary: "Instance {{ $labels.instance }} with load between 4 and 6"
       description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 4 and 6."
@@ -51,7 +56,8 @@ groups:
     expr: node_load1 > 5 and node_load1 > 7
     for: 10s
     labels:
-      severity: page
+      severity: warning
+      oid: 1.3.6.1.4.1.50495.15.1.2.50.5
     annotations:
       summary: "Instance {{ $labels.instance }} with load between 5 and 7"
       description: "{{ $labels.instance }} of job {{ $labels.job }} with load between 5 and 7."
@@ -60,7 +66,8 @@ groups:
     expr: node_load1 > 6
     for: 5s
     labels:
-      severity: page
+      severity: critical
+      oid: 1.3.6.1.4.1.50495.15.1.2.50.6
     annotations:
       summary: "Instance {{ $labels.instance }} with load over 6 for 10s."
       description: "{{ $labels.instance }} of job {{ $labels.job }} with load over 6 for 10s."

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,6 +11,10 @@ scrape_configs:
   - job_name: 'node-exporter'
     static_configs:
       - targets: ['localhost:9100']
+  - job_name: 'prometheus-webhook-snmp'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['localhost:9099']
 
 alerting:
   alertmanagers:


### PR DESCRIPTION
Adapt configurations to get the prometheus-webhook-snmp Prometheus Alertmanager webhook working.

Signed-off-by: Volker Theile <vtheile@suse.com>