### PR TITLE
Use "npm ci" to prevent installing new updates during development

### DIFF
--- a/shared/bin/npm-start.sh
+++ b/shared/bin/npm-start.sh
@@ -6,6 +6,6 @@ setup-proxy.sh
 
 cd /ceph/src/pybind/mgr/dashboard/frontend
 source /ceph/build/src/pybind/mgr/dashboard/node-env/bin/activate
-npm i
+npm ci
 
 npm start


### PR DESCRIPTION
Signed-off-by: Tiago Melo <tmelo@suse.com>