### PR TITLE
Fix python2 and gcc9 problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ RUN zypper -n dup
 RUN zypper -n install \
         iproute2 net-tools-deprecated zsh lttng-ust-devel babeltrace-devel \
         bash vim tmux git aaa_base ccache wget jq google-opensans-fonts psmisc \
-        python python3-pip \
-        python-devel python3-devel \
+        gcc8 gcc8-c++ libstdc++6-devel-gcc8 \
+        python python-devel python2-virtualenv \
+        python3-pip python3-devel \
         python3-bcrypt \
         python3-CherryPy \
         python3-Cython \

--- a/shared/bin/setup-ceph.sh
+++ b/shared/bin/setup-ceph.sh
@@ -15,6 +15,13 @@ NPROC=${NPROC:-$(nproc --ignore=2)}
 zypper -n install libxmlsec1-1 libxmlsec1-nss1 libxmlsec1-openssl1 xmlsec1-devel xmlsec1-openssl-devel
 pip install python3-saml
 
+# temporary fix, spdk doesn't work with gcc9
+rm /usr/bin/gcc
+rm /usr/bin/g++
+
+ln -s /usr/bin/gcc-8 /usr/bin/gcc
+ln -s /usr/bin/g++-8 /usr/bin/g++
+
 if [ "$CLEAN" == "true" ]; then
     echo "CLEAN INSTALL"
     rm -rf /ceph/build/


### PR DESCRIPTION
SPDK is not working with gcc9, so we have to downgrade to v8,

install-deps.sh was failing because python2-virtualenv was missing.

Signed-off-by: Tiago Melo <tmelo@suse.com>