### PR TITLE
Update Grafana config and allow embedding in iframe

### DIFF
--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -4,15 +4,18 @@
 # change
 
 # possible values : production, development
-; app_mode = production
+;app_mode = production
 
 # instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
-; instance_name = ${HOSTNAME}
+;instance_name = ${HOSTNAME}
 
 #################################### Paths ####################################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
 ;data = /var/lib/grafana
+
+# Temporary files in `data` directory older than given duration will be removed
+;temp_data_lifetime = 24h
 
 # Directory where grafana can store logs
 ;logs = /var/log/grafana
@@ -21,7 +24,7 @@
 ;plugins = /var/lib/grafana/plugins
 
 # folder that contains provisioning config files that grafana will apply on startup and while running.
-; provisioning = conf/provisioning
+;provisioning = conf/provisioning
 
 #################################### Server ####################################
 [server]
@@ -64,7 +67,7 @@ http_port = 3000
 #################################### Database ####################################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password
-# as seperate properties or as on string using the url propertie.
+# as separate properties or as on string using the url properties.
 
 # Either "mysql", "postgres" or "sqlite3", it's your choice
 ;type = sqlite3
@@ -96,27 +99,19 @@ http_port = 3000
 # Set to true to log the sql calls and execution times.
 log_queries =
 
-#################################### Session ####################################
-[session]
-# Either "memory", "file", "redis", "mysql", "postgres", default is "file"
-;provider = file
+# For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+;cache_mode = private
 
-# Provider config options
-# memory: not have any config yet
-# file: session dir path, is relative to grafana data_path
+#################################### Cache server #############################
+[remote_cache]
+# Either "redis", "memcached" or "database" default is "database"
+;type = database
+
+# cache connectionstring options
+# database: will use Grafana primary database.
 # redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
-# mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
-# postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable
-;provider_config = sessions
-
-# Session cookie name
-;cookie_name = grafana_sess
-
-# If you use session in https only, default is false
-;cookie_secure = false
-
-# Session life time, default is 86400
-;session_life_time = 86400
+# memcache: 127.0.0.1:11211
+;connstr =
 
 #################################### Data proxy ###########################
 [dataproxy]
@@ -124,6 +119,11 @@ log_queries =
 # This enables data proxy logging, default is false
 ;logging = false
 
+# How long the data proxy should wait before timing out default is 30 (seconds)
+;timeout = 30
+
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+;send_user_header = false
 
 #################################### Analytics ####################################
 [analytics]
@@ -143,6 +143,9 @@ log_queries =
 # Google Analytics universal tracking code, only enabled if you specify an id here
 ;google_analytics_ua_id =
 
+# Google Tag Manager ID, only enabled if you specify an id here
+;google_tag_manager_id =
+
 #################################### Security ####################################
 [security]
 # default admin user, created on startup
@@ -154,11 +157,6 @@ log_queries =
 # used for signing
 ;secret_key = SW2YcwTIb9zpOOhoPsMm
 
-# Auto-login remember days
-;login_remember_days = 7
-;cookie_username = grafana_user
-;cookie_remember_name = grafana_remember
-
 # disable gravatar profile images
 ;disable_gravatar = false
 
@@ -167,6 +165,15 @@ log_queries =
 
 # disable protection against brute force login attempts
 ;disable_brute_force_login_protection = false
+
+# set to true if you host Grafana behind HTTPS. default is false.
+;cookie_secure = false
+
+# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+;cookie_samesite = lax
+
+# set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
+allow_embedding = true
 
 #################################### Snapshots ###########################
 [snapshots]
@@ -199,6 +206,7 @@ log_queries =
 
 # Background text for the user field on the login page
 ;login_hint = email or username
+;password_hint = password
 
 # Default UI theme ("dark" or "light")
 default_theme = light
@@ -211,14 +219,36 @@ default_theme = light
 # Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
 ;viewers_can_edit = false
 
+# Editors can administrate dashboard, folders and teams they create
+;editors_can_admin = false
+
 [auth]
+# Login cookie name
+;login_cookie_name = grafana_session
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
+;login_maximum_inactive_lifetime_days = 7
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+;login_maximum_lifetime_days = 30
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+;token_rotation_interval_minutes = 10
+
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false
 
 # Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
 ;disable_signout_menu = false
 
-#################################### Anonymous Auth ##########################
+# URL to redirect the user to after sign out
+;signout_redirect_url =
+
+# Set to true to attempt login with OAuth automatically, skipping the login screen.
+# This setting is ignored if multiple OAuth providers are configured.
+;oauth_auto_login = false
+
+#################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access
 enabled = true
@@ -267,6 +297,14 @@ org_role = Viewer
 ;api_url = https://foo.bar/user
 ;team_ids =
 ;allowed_organizations =
+;tls_skip_verify_insecure = false
+;tls_client_cert =
+;tls_client_key =
+;tls_client_ca =
+
+; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+;send_client_credentials_via_post = false
 
 #################################### Grafana.com Auth ####################
 [auth.grafana_com]
@@ -285,6 +323,7 @@ org_role = Viewer
 ;auto_sign_up = true
 ;ldap_sync_ttl = 60
 ;whitelist = 192.168.1.1, 192.168.2.1
+;headers = Email:X-User-Email, Name:X-User-Name
 
 #################################### Basic Auth ##########################
 [auth.basic]
@@ -325,7 +364,6 @@ org_role = Viewer
 
 # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
 ;filters =
-
 
 # For "console" mode only
 [log.console]
@@ -372,13 +410,37 @@ org_role = Viewer
 # Syslog tag. By default, the process' argv[0] is used.
 ;tag =
 
-
 #################################### Alerting ############################
 [alerting]
 # Disable alerting engine & UI features
 ;enabled = true
 # Makes it possible to turn off alert rule execution but alerting UI is visible
 ;execute_alerts = true
+
+# Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+;error_or_timeout = alerting
+
+# Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+;nodata_or_nullvalues = no_data
+
+# Alert notifications can include images, but rendering many images at the same time can overload the server
+# This limit will protect the server from render overloading and make sure notifications are sent out quickly
+;concurrent_render_limit = 5
+
+
+# Default setting for alert calculation timeout. Default value is 30
+;evaluation_timeout_seconds = 30
+
+# Default setting for alert notification timeout. Default value is 30
+;notification_timeout_seconds = 30
+
+# Default setting for max attempts to sending alert notifications. Default value is 3
+;max_attempts = 3
+
+#################################### Explore #############################
+[explore]
+# Enable the Explore section
+;enabled = true
 
 #################################### Internal Grafana Metrics ##########################
 # Metrics available at HTTP API Url /metrics
@@ -413,7 +475,7 @@ org_role = Viewer
 ;sampler_param = 1
 
 #################################### Grafana.com integration  ##########################
-# Url used to to import dashboards directly from Grafana.com
+# Url used to import dashboards directly from Grafana.com
 [grafana_com]
 ;url = https://grafana.com
 
@@ -448,3 +510,21 @@ org_role = Viewer
 
 [external_image_storage.local]
 # does not require any configuration
+
+[rendering]
+# Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+;server_url =
+;callback_url =
+
+[enterprise]
+# Path to a valid Grafana Enterprise license.jwt file
+;license_path =
+
+[panels]
+# If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
+;disable_sanitize_html = false
+
+[plugins]
+;enable_alpha = false
+;app_tls_skip_verify_insecure = false
+


### PR DESCRIPTION
Update default configuration file from grafana/grafana:6.2.1

Starts from Grafana 6.2.0, embedding dashboards in iframes is not
allowed by default. Enable this in configuration file.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>