### PR TITLE
Remove gcc9 temporary fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN zypper -n dup
 RUN zypper -n install \
         iproute2 net-tools-deprecated zsh lttng-ust-devel babeltrace-devel \
         bash vim tmux git aaa_base ccache wget jq google-opensans-fonts psmisc \
-        gcc8 gcc8-c++ libstdc++6-devel-gcc8 \
         python python-devel python2-virtualenv \
         python3-pip python3-devel \
         python3-bcrypt \

--- a/shared/bin/setup-ceph.sh
+++ b/shared/bin/setup-ceph.sh
@@ -15,13 +15,6 @@ NPROC=${NPROC:-$(nproc --ignore=2)}
 zypper -n install libxmlsec1-1 libxmlsec1-nss1 libxmlsec1-openssl1 xmlsec1-devel xmlsec1-openssl-devel
 pip install python3-saml
 
-# temporary fix, spdk doesn't work with gcc9
-rm /usr/bin/gcc
-rm /usr/bin/g++
-
-ln -s /usr/bin/gcc-8 /usr/bin/gcc
-ln -s /usr/bin/g++-8 /usr/bin/g++
-
 if [ "$CLEAN" == "true" ]; then
     echo "CLEAN INSTALL"
     rm -rf /ceph/build/


### PR DESCRIPTION
Problem with SPDK has been fix in ceph.
gcc8 was now causing problems with RocksDB.

Signed-off-by: Tiago Melo <tmelo@suse.com>