### PR TITLE
Add NG_CLI_ANALYTICS environment variable

### DIFF
--- a/shared/zsh/.zshrc
+++ b/shared/zsh/.zshrc
@@ -72,6 +72,7 @@ source $ZSH/oh-my-zsh.sh
 # export MANPATH="/usr/local/man:$MANPATH"
 export SOURCE_DATE_EPOCH=946684800
 export PATH=${PATH}:/shared/bin
+export NG_CLI_ANALYTICS="false"
 
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8


### PR DESCRIPTION
This will allow us to run npm ci without having to interact with the cli.

Signed-off-by: Tiago Melo <tmelo@suse.com>