### PR TITLE
Install scipy for diskprediction_local module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN zypper -n install \
         python3-pyOpenSSL \
         python3-requests \
         python3-Routes \
-        python3-Werkzeug
+        python3-Werkzeug \
+        python3-scipy
 
 # temporary fix for error regarding version of tempora
 RUN pip3 install tempora==1.8 backports.functools_lru_cache


### PR DESCRIPTION
python3-scipy needs to be installed for loading diskprediction_local
module. This fixes run-frontend-e2e-tests.sh failure in container.

See https://tracker.ceph.com/issues/43230.
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

*NOTE*: This only applies to new created container, for existing one simply run:

```
zypper in python3-scipy
```