### PR TITLE
Add binds for ceph and npm

### DIFF
--- a/shared/docker/install-omz.sh
+++ b/shared/docker/install-omz.sh
@@ -7,3 +7,6 @@ ln -s /shared/zsh/.zshrc /root/.zshrc
 # sym link for dash.plugin.zsh
 mkdir ~/.oh-my-zsh/custom/plugins/dash
 ln -s /shared/zsh/dash.plugin.zsh ~/.oh-my-zsh/custom/plugins/dash/dash.plugin.zsh
+# sym link for binds.plugin.zsh
+mkdir ~/.oh-my-zsh/custom/plugins/binds
+ln -s /shared/zsh/binds.plugin.zsh ~/.oh-my-zsh/custom/plugins/binds/binds.plugin.zsh

--- a/shared/zsh/.zshrc
+++ b/shared/zsh/.zshrc
@@ -62,7 +62,7 @@ ZSH_THEME="bira"
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(
-  git npm suse pip colored-man-pages dash
+  git npm suse pip colored-man-pages dash binds
 )
 
 source $ZSH/oh-my-zsh.sh

--- a/shared/zsh/binds.plugin.zsh
+++ b/shared/zsh/binds.plugin.zsh
@@ -1,0 +1,27 @@
+#compdef binds
+#autoload
+
+npm () {
+  DIR=$(pwd)
+  source /ceph/build/src/pybind/mgr/dashboard/node-env/bin/activate .
+  cd /ceph/src/pybind/mgr/dashboard/frontend
+  command npm $@
+  deactivate
+  cd $DIR
+}
+
+npx () {
+  DIR=$(pwd)
+  source /ceph/build/src/pybind/mgr/dashboard/node-env/bin/activate .
+  cd /ceph/src/pybind/mgr/dashboard/frontend
+  command npx $@
+  deactivate
+  cd $DIR
+}
+
+ceph () {
+  DIR=$(pwd)
+  cd /ceph/build
+  bin/ceph $@
+  cd $DIR
+}


### PR DESCRIPTION
This allows us to call 'ceph' and 'npm' from any directory and they will be
executed in the proper directory.

'ceph' will be executed in '/ceph/build'.

'npm' will first activate the nodeenv and
then execute in 'dashboard/frontend'.

Signed-off-by: Stephan Müller <smueller@suse.com>
Signed-off-by: Tiago Melo <tmelo@suse.com>