### PR TITLE
Add script to install NFS Ganesha easily in the Docker container.

### DIFF
--- a/shared/bin/setup-nfs.sh
+++ b/shared/bin/setup-nfs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+zypper -n install nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rados-grace

--- a/shared/bin/start-ceph.sh
+++ b/shared/bin/start-ceph.sh
@@ -4,6 +4,10 @@ set -e
 
 find /ceph/build/ -name "mgr.*.log" -type f -delete
 
+if rpm --quiet --query nfs-ganesha-ceph; then
+    export GANESHA=1
+fi
+
 cd /ceph/build
 RGW=1 ../src/vstart.sh -d -n -x
 


### PR DESCRIPTION
To install NFS Ganesha run the 'setup-nfs.sh' script. This will install all necessary packages. The 'start-ceph.sh' script will automatically take care to setup vstart correctly if the NFS packages are installed.

Signed-off-by: Volker Theile <vtheile@suse.com>