### PR TITLE
Update python2-virtualenv dependency to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN zypper -n install \
         iproute2 net-tools-deprecated zsh lttng-ust-devel babeltrace-devel \
         bash vim tmux git aaa_base ccache wget jq google-opensans-fonts psmisc \
         rpm-build smartmontools \
-        python python-devel python2-virtualenv \
+        python python-devel \
+        python3-virtualenv \
         python3-pip python3-devel \
         python3-bcrypt \
         python3-CherryPy \


### PR DESCRIPTION
Update dependency to python3-virtualenv because it's no longer available in tumbleweed.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>