### PR TITLE
Allow access to angular remotely

### DIFF
--- a/shared/bin/npm-start.sh
+++ b/shared/bin/npm-start.sh
@@ -8,4 +8,4 @@ cd /ceph/src/pybind/mgr/dashboard/frontend
 source /ceph/build/src/pybind/mgr/dashboard/node-env/bin/activate
 npm ci --unsafe-perm
 
-npm start
+npm start -- --disableHostCheck=true


### PR DESCRIPTION
Currently is not possible to access angular from a different machine.

Signed-off-by: Tiago Melo <tmelo@suse.com>