### PR TITLE
Add a missing package for nfs-ganesha

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ All of them are now accessible through the `dash` command:
 When you press `tab` it will show you a list of all scripts and their
 description.
 
+### Enable NFS-Ganesha support (Optional)
+
+If you need to test NFS feature in Ceph Dashboard, at least one nfs-ganesha
+daemon must be provisioned. The `start-ceph.sh` script that introduced in the
+later session will ask `vstart` script to spawn a nfs-ganesha daemon if
+required packages are installed. Run the following script to install required
+packages:
+
+    (docker)# setup-nfs.sh
+
 ### Start Ceph Development Environment
 
 To start up the compiled Ceph cluster, you can use the `vstart.sh` script, which

--- a/shared/bin/setup-nfs.sh
+++ b/shared/bin/setup-nfs.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-zypper -n install nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rados-grace
+zypper -n install nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rados-grace nfs-ganesha-rados-urls

--- a/shared/bin/start-ceph.sh
+++ b/shared/bin/start-ceph.sh
@@ -5,7 +5,11 @@ set -e
 find /ceph/build/ -name "mgr.*.log" -type f -delete
 
 if rpm --quiet --query nfs-ganesha-ceph; then
-    export GANESHA=1
+    if grep -q pacific /ceph/src/ceph_release; then
+        export NFS=1
+    else
+        export GANESHA=1
+    fi
 fi
 
 cd /ceph/build


### PR DESCRIPTION
- `nfs-ganesha-rados-urls` package is required to create exports.
- Update README.md: required step to bring up NFS support.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>