### PR TITLE
Always pull images when building images.

### DIFF
--- a/nautilus.Dockerfile
+++ b/nautilus.Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.0
+FROM opensuse/leap:15.1
 LABEL maintainer="rimarques@suse.com"
 
 RUN zypper --gpg-auto-import-keys ref

--- a/setup.sh
+++ b/setup.sh
@@ -9,23 +9,25 @@ VERSION="${VERSION:-master}"
 docker stop $NAME
 docker rm $NAME
 
+DOCKER_BUILD_OPTS="--pull"
+
 # Build updated version of the image
 case "$VERSION" in
 "mimic")
   TAG="ceph-dev-docker-mimic"
-  docker build -t $TAG -f mimic.Dockerfile .
+  docker build $DOCKER_BUILD_OPTS -t $TAG -f mimic.Dockerfile .
   ;;
 "nautilus")
   TAG="ceph-dev-docker-nautilus"
-  docker build -t $TAG -f nautilus.Dockerfile .
+  docker build $DOCKER_BUILD_OPTS -t $TAG -f nautilus.Dockerfile .
   ;;
 "octopus")
   TAG="ceph-dev-docker-octopus"
-  docker build -t $TAG -f octopus.Dockerfile .
+  docker build $DOCKER_BUILD_OPTS -t $TAG -f octopus.Dockerfile .
   ;;
 *)
   TAG="ceph-dev-docker"
-  docker build -t $TAG .
+  docker build $DOCKER_BUILD_OPTS -t $TAG .
   ;;
 esac
 


### PR DESCRIPTION
If the local cached image is out of date for some time, it might cause
problem when updating packages.

Nautilus' base image is updated to opensuse/leap:15.1 since 15.0 is eol.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>