### PR TITLE
Use make to install frontend packages

### DIFF
--- a/shared/bin/npm-start.sh
+++ b/shared/bin/npm-start.sh
@@ -4,8 +4,10 @@ set -e
 
 setup-proxy.sh
 
+pushd /ceph/build
+make mgr-dashboard-frontend-deps
+popd
+
 cd /ceph/src/pybind/mgr/dashboard/frontend
 source /ceph/build/src/pybind/mgr/dashboard/node-env/bin/activate
-npm ci --unsafe-perm
-
 npm start -- --disableHostCheck=true


### PR DESCRIPTION
This prevents reinstalling packages if nothing was changed.

Signed-off-by: Tiago Melo <tmelo@suse.com>