### PR TITLE
start-ceph.sh: enable NFS in octopus

### DIFF
--- a/shared/bin/start-ceph.sh
+++ b/shared/bin/start-ceph.sh
@@ -5,10 +5,9 @@ set -e
 find /ceph/build/ -name "mgr.*.log" -type f -delete
 
 if rpm --quiet --query nfs-ganesha-ceph; then
-    if grep -q pacific /ceph/src/ceph_release; then
+    CEPH_VERSION=$(head -n1 /ceph/src/ceph_release) 
+    if [ $CEPH_VERSION -ge 15 ]; then
         export NFS=1
-    else
-        export GANESHA=1
     fi
 fi
 


### PR DESCRIPTION
The NFS variable change in the vstart.sh had been [backported to octopus](https://github.com/ceph/ceph/commit/2fa01181ccdbecd127387d12f1ff4f98d7330940).
Adapt to this change. Ceph version detection is more reliable now.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>