### PR TITLE
Read RGW keys from files

### DIFF
--- a/shared/bin/create-dashboard-rgw-user.sh
+++ b/shared/bin/create-dashboard-rgw-user.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+: ${CEPH_DEV_DOCKER_CONFIG_DIR:="$HOME/.ceph-dev-docker"}
+mkdir -p $CEPH_DEV_DOCKER_CONFIG_DIR
+
 #--------------
 # Configure RGW
 #--------------
@@ -9,5 +12,13 @@ set -e
 cd /ceph/build
 ./bin/radosgw-admin user create --uid=dev --display-name=Developer --system
 ./bin/ceph dashboard set-rgw-api-user-id dev
-./bin/ceph dashboard set-rgw-api-access-key `./bin/radosgw-admin user info --uid=dev | jq -r ".keys[0].access_key"`
-./bin/ceph dashboard set-rgw-api-secret-key `./bin/radosgw-admin user info --uid=dev | jq -r ".keys[0].secret_key"`
+
+RGW_ACCESS_KEY="${CEPH_DEV_DOCKER_CONFIG_DIR}/rgw_access_key"
+RGW_SECRET_KEY="${CEPH_DEV_DOCKER_CONFIG_DIR}/rgw_secret_key"
+./bin/radosgw-admin user info --uid=dev | jq -jr ".keys[0].access_key" > $RGW_ACCESS_KEY
+./bin/radosgw-admin user info --uid=dev | jq -jr ".keys[0].secret_key" > $RGW_SECRET_KEY
+chmod 600 $RGW_ACCESS_KEY
+chmod 600 $RGW_SECRET_KEY
+
+./bin/ceph dashboard set-rgw-api-access-key -i $RGW_ACCESS_KEY || ./bin/ceph dashboard set-rgw-api-access-key "$(cat $RGW_ACCESS_KEY)"
+./bin/ceph dashboard set-rgw-api-secret-key -i $RGW_SECRET_KEY || ./bin/ceph dashboard set-rgw-api-secret-key "$(cat $RGW_SECRET_KEY)"


### PR DESCRIPTION
The way to set RGW keys is changed after https://github.com/ceph/ceph/pull/38284.
Store the keys in a config folder and read the keys from there.
The original method is still kept as a fallback.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>